### PR TITLE
fix: restore test suite and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 14.x
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build package
+        run: yarn build
+
+      - name: Run tests
+        run: yarn test-without-coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ♿ Agastya
 
-![Travis CI](https://travis-ci.org/OswaldLabsOpenSource/agastya.svg?branch=master)
+[![CI](https://github.com/OswaldLabsOpenSource/agastya/actions/workflows/ci.yml/badge.svg)](https://github.com/OswaldLabsOpenSource/agastya/actions/workflows/ci.yml)
 ![Dependencies](https://img.shields.io/david/OswaldLabsOpenSource/agastya.svg)
 ![Dev dependencies](https://img.shields.io/david/dev/OswaldLabsOpenSource/agastya.svg)
 [![License](https://img.shields.io/github/license/OswaldLabsOpenSource/agastya.svg)](https://github.com/OswaldLabsOpenSource/agastya/blob/master/LICENSE)

--- a/docs/random.d.ts
+++ b/docs/random.d.ts
@@ -1,1 +1,0 @@
-export declare const random: () => string;

--- a/tests/random.test.ts
+++ b/tests/random.test.ts
@@ -1,5 +1,0 @@
-import { random } from "../src/random";
-
-test("should be a string", () => {
-  expect(typeof random()).toBe("string");
-});


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow for builds and tests on `master` and pull requests
- Removes the stale `tests/random.test.ts` fixture that imported a non-existent `src/random` module
- Removes the matching stale generated `docs/random.d.ts` artifact and updates the README CI badge

## Test Plan
- `npx -y -p node@14 -p yarn@1.22.22 -c 'yarn install --frozen-lockfile'`
- `npx -y -p node@14 -p yarn@1.22.22 -c 'yarn build && yarn test-without-coverage'`
- `/tmp/actionlint/actionlint .github/workflows/ci.yml`
- `git diff --cached --check`
